### PR TITLE
Fix Docker Compose setup - command return types, composer install

### DIFF
--- a/app/src/ActivityRetry/ExecuteCommand.php
+++ b/app/src/ActivityRetry/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'activity-retry';
     protected const DESCRIPTION = 'Execute ActivityRetry\GreetingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             GreetingWorkflowInterface::class,

--- a/app/src/AsyncActivity/ExecuteCommand.php
+++ b/app/src/AsyncActivity/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'async-activity';
     protected const DESCRIPTION = 'Execute AsyncActivity\GreetingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             AsyncGreetingWorkflowInterface::class,

--- a/app/src/AsyncActivityCompletion/CompleteCommand.php
+++ b/app/src/AsyncActivityCompletion/CompleteCommand.php
@@ -26,7 +26,7 @@ class CompleteCommand extends Command
         ['message', InputArgument::REQUIRED, 'Activity token'],
     ];
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         // @@@SNIPSTART samples-php-async-activity-completion-completebytoken
         $client = $this->workflowClient->newActivityCompletionClient();

--- a/app/src/AsyncActivityCompletion/ExecuteCommand.php
+++ b/app/src/AsyncActivityCompletion/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'user-activity:start';
     protected const DESCRIPTION = 'Execute AsyncActivityCompletion\GreetingWorkflow and wait for user greeting';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             GreetingWorkflowInterface::class,

--- a/app/src/AsyncClosure/ExecuteCommand.php
+++ b/app/src/AsyncClosure/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'async-closure';
     protected const DESCRIPTION = 'Execute AsyncClosure\GreetingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             AsyncGreetingWorkflowInterface::class,

--- a/app/src/BookingSaga/ExecuteCommand.php
+++ b/app/src/BookingSaga/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'booking-saga';
     protected const DESCRIPTION = 'Execute BookingSaga\TripBookingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             TripBookingWorkflowInterface::class,

--- a/app/src/CancellationScope/ExecuteCommand.php
+++ b/app/src/CancellationScope/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'cancellation-scope';
     protected const DESCRIPTION = 'Execute CancellationScope\GreetingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             GreetingWorkflowInterface::class,

--- a/app/src/Child/ExecuteCommand.php
+++ b/app/src/Child/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'child';
     protected const DESCRIPTION = 'Execute Child\ParentWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             ParentWorkflowInterface::class,

--- a/app/src/Cron/ExecuteCommand.php
+++ b/app/src/Cron/ExecuteCommand.php
@@ -23,7 +23,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'cron';
     protected const DESCRIPTION = 'Start Cron\CronWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         // Sets the cron schedule using the WorkflowOptions.
         // The cron format is parsed by "https://github.com/robfig/cron" library.

--- a/app/src/Exception/ExecuteCommand.php
+++ b/app/src/Exception/ExecuteCommand.php
@@ -23,7 +23,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'exception';
     protected const DESCRIPTION = 'Execute Exception\FailedWorkflow with multiple signals';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             FailedWorkflow::class,

--- a/app/src/FileProcessing/ExecuteCommand.php
+++ b/app/src/FileProcessing/ExecuteCommand.php
@@ -28,7 +28,7 @@ class ExecuteCommand extends Command
         ['url', InputArgument::REQUIRED, 'Download URL']
     ];
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             FileProcessingWorkflowInterface::class,

--- a/app/src/Interceptors/ExecuteCommand.php
+++ b/app/src/Interceptors/ExecuteCommand.php
@@ -23,7 +23,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'interceptors';
     protected const DESCRIPTION = 'Execute workflow with interceptors';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             TestActivityAttributesInterceptor::class,

--- a/app/src/LocalActivity/ExecuteCommand.php
+++ b/app/src/LocalActivity/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'local-activity';
     protected const DESCRIPTION = 'Execute LocalActivity\GreetingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             GreetingWorkflowInterface::class,

--- a/app/src/MoneyBatch/ExecuteCommand.php
+++ b/app/src/MoneyBatch/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'money-batch';
     protected const DESCRIPTION = 'Execute MoneyBatch\MoneyBatchWorkflow with multiple signals and queries';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             MoneyBatchWorkflowInterface::class,

--- a/app/src/MoneyTransfer/ExecuteCommand.php
+++ b/app/src/MoneyTransfer/ExecuteCommand.php
@@ -20,7 +20,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'money-transfer';
     protected const DESCRIPTION = 'Execute MoneyTransferWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(AccountTransferWorkflowInterface::class);
         $output->writeln("Starting <comment>MoneyTransferWorkflow</comment>... ");

--- a/app/src/Periodic/ExecuteCommand.php
+++ b/app/src/Periodic/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'periodic:start';
     protected const DESCRIPTION = 'Start Periodic\PeriodicWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             PeriodicWorkflowInterface::class,

--- a/app/src/Periodic/StopCommand.php
+++ b/app/src/Periodic/StopCommand.php
@@ -20,7 +20,7 @@ class StopCommand extends Command
     protected const NAME = 'periodic:stop';
     protected const DESCRIPTION = 'Stop Periodic\PeriodicWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newUntypedRunningWorkflowStub(
             PeriodicWorkflowInterface::WORKFLOW_ID

--- a/app/src/PolymorphicActivity/ExecuteCommand.php
+++ b/app/src/PolymorphicActivity/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'polymorphic';
     protected const DESCRIPTION = 'Execute PolymorphicActivity\GreetingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             GreetingWorkflowInterface::class,

--- a/app/src/Query/ExecuteCommand.php
+++ b/app/src/Query/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'query';
     protected const DESCRIPTION = 'Execute Query\QueryWorkflow with additional query and timer';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             QueryWorkflowInterface::class,

--- a/app/src/Replay/ExecuteCommand.php
+++ b/app/src/Replay/ExecuteCommand.php
@@ -30,7 +30,7 @@ class ExecuteCommand extends Command
     ];
     protected const DESCRIPTION = 'Replay workflow executions from history events';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $replayer = new WorkflowReplayer();
         $workflowType = $input->getArgument('workflow-type');

--- a/app/src/Saga/ExecuteCommand.php
+++ b/app/src/Saga/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'saga';
     protected const DESCRIPTION = 'Execute Saga\SagaWorkflow with multiple signals';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             SagaWorkflowInterface::class,

--- a/app/src/Schedule/CreateCommand.php
+++ b/app/src/Schedule/CreateCommand.php
@@ -34,7 +34,7 @@ class CreateCommand extends Command
     ];
 
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $specInit = $spec = Schedule\Spec\ScheduleSpec::new()
             ->withJitter('10m');

--- a/app/src/Schedule/DeleteCommand.php
+++ b/app/src/Schedule/DeleteCommand.php
@@ -23,7 +23,7 @@ class DeleteCommand extends Command
     protected const NAME = 'schedule:delete';
     protected const DESCRIPTION = 'Delete scheduled workflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $handle = $this->scheduleClient->getHandle(ScheduleWorkflowInterface::SCHEDULE_ID);
 

--- a/app/src/Schedule/DescribeCommand.php
+++ b/app/src/Schedule/DescribeCommand.php
@@ -21,7 +21,7 @@ class DescribeCommand extends Command
     protected const NAME = 'schedule:describe';
     protected const DESCRIPTION = 'Describe the Schedule';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $handle = $this->scheduleClient->getHandle(ScheduleWorkflowInterface::SCHEDULE_ID);
 

--- a/app/src/Schedule/ListCommand.php
+++ b/app/src/Schedule/ListCommand.php
@@ -21,7 +21,7 @@ class ListCommand extends Command
     protected const NAME = 'schedule:list';
     protected const DESCRIPTION = 'List all Schedules';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $schedules = $this->scheduleClient->listSchedules();
 

--- a/app/src/SearchAttributes/ExecuteCommand.php
+++ b/app/src/SearchAttributes/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'search-attributes';
     protected const DESCRIPTION = 'Execute SearchAttributes\GreetingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             GreetingWorkflowInterface::class,

--- a/app/src/Signal/ExecuteCommand.php
+++ b/app/src/Signal/ExecuteCommand.php
@@ -22,7 +22,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'signal';
     protected const DESCRIPTION = 'Execute Signal\SignalWorkflow with multiple signals';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             SignalWorkflowInterface::class,

--- a/app/src/SimpleActivity/ExecuteCommand.php
+++ b/app/src/SimpleActivity/ExecuteCommand.php
@@ -23,7 +23,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'simple-activity';
     protected const DESCRIPTION = 'Execute SimpleActivity\GreetingWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             GreetingWorkflowInterface::class,

--- a/app/src/Subscription/CancelCommand.php
+++ b/app/src/Subscription/CancelCommand.php
@@ -28,7 +28,7 @@ class CancelCommand extends Command
         ['userID', InputArgument::REQUIRED, 'Unique user ID']
     ];
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $userID = $input->getArgument('userID');
 

--- a/app/src/Subscription/SubscribeCommand.php
+++ b/app/src/Subscription/SubscribeCommand.php
@@ -29,7 +29,7 @@ class SubscribeCommand extends Command
         ['userID', InputArgument::REQUIRED, 'Unique user ID']
     ];
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $userID = $input->getArgument('userID');
 

--- a/app/src/UpdatableTimer/ExecuteCommand.php
+++ b/app/src/UpdatableTimer/ExecuteCommand.php
@@ -24,7 +24,7 @@ class ExecuteCommand extends Command
     protected const NAME = 'updatable-timer:start';
     protected const DESCRIPTION = 'Execute UpdatableTimer\DynamicSleepWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newWorkflowStub(
             DynamicSleepWorkflowInterface::class,

--- a/app/src/UpdatableTimer/ProlongCommand.php
+++ b/app/src/UpdatableTimer/ProlongCommand.php
@@ -20,7 +20,7 @@ class ProlongCommand extends Command
     protected const NAME = 'updatable-timer:prolong';
     protected const DESCRIPTION = 'Prolong the duration of UpdatableTimer\DynamicSleepWorkflow';
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $workflow = $this->workflowClient->newRunningWorkflowStub(
             DynamicSleepWorkflowInterface::class,

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -25,15 +25,14 @@ COPY --from=temporalio/admin-tools /usr/local/bin/tctl /usr/local/bin/tctl
 # Install Composer
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
-# Wait for Temporal service to star up
-COPY wait-for-temporal.sh /usr/local/bin
-RUN chmod +x /usr/local/bin/wait-for-temporal.sh
-
-# Copy application codebase
 WORKDIR /var/app
 COPY app/ /var/app
 
 RUN composer install
+
+# Wait for Temporal service to start up
+COPY wait-for-temporal.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/wait-for-temporal.sh
 
 # Setup RoadRunner
 RUN vendor/bin/rr get --no-interaction \

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -25,6 +25,7 @@ COPY --from=temporalio/admin-tools /usr/local/bin/tctl /usr/local/bin/tctl
 # Install Composer
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
+# Copy application codebase
 WORKDIR /var/app
 COPY app/ /var/app
 


### PR DESCRIPTION
## What was changed

- Added missing return types to sample commands;
- Moved `composer install` to be run earlier;

## Why?

- Fatal error in `app` container because of missing return types in sample commands - incompatible with `Symfony\Component\Console\Command\Command::execute`;
- Fatal error in `app` container because of missing vendors (`composer install` had to be run locally first, with all the pre-requisites, to get it to start up correctly);

## Checklist

2. How was this tested:
On multiple devices/OS'es, we could not successfully start the `app` container before solving both of these issues, or at least adding the return types and running `composer install` locally for the first time.