### PR TITLE
55 allowing for repeated pairs in update dice scoring

### DIFF
--- a/README-Vid.md
+++ b/README-Vid.md
@@ -1,0 +1,31 @@
+# README-Vid.md
+
+## Notes on PHP Temporal samples
+
+You can walk through all the samples by standing up docker
+`docker compose up`
+and then in a new tab, runing sample name in an 'exec' like so:
+`docker-compose exec app php app.php update`
+
+Each app/src/ sample dir has a README and in it is the cmd to run that sample.
+
+Here's a quick way to walk through all 31
+Build the list of samples:
+
+```
+# get the list of samples from the README's and transform the string
+samples=$(ag -iQu 'php ./app/app.php ' | grep 'php ./app/app.php' | gsed -E 's~\.md:[0-9]+:php ./app/~.md:php ~' | awk -F'md:' '{print "docker-compose exec app "$2}');
+# set your iterator
+i=1;
+```
+
+Run this command over and over again to run the sample, see the output and queue up the next sample (i+1);
+
+```
+echo $i:; echo "$samples" | awk "NR==$i" && $(echo "$samples" | awk "NR==$i"); i=$((i+1))
+```
+
+If the above fails. You can cmd+. and then `echo $i` to see where you are in the list. If you need to manually change that number `i=7`; do that and run the echo line again.
+
+For the most part you can cut and paste once; hit enter;
+Then: up arrow; enter; repeat

--- a/app/src/Updates/Zonk/Rules.php
+++ b/app/src/Updates/Zonk/Rules.php
@@ -40,7 +40,7 @@ final class Rules
             }
 
             // Three pairs
-            if (\count(\array_unique($values)) === 3
+            if (\count(\array_unique($values)) <= 3
                 && $values[0] === $values[1] && $values[2] === $values[3] && $values[4] === $values[5]
             ) {
                 return Rules::SCORE_THREE_PAIRS;


### PR DESCRIPTION
## What was changed
Fixes issue #55
Quick change to the update sample to allow for repeated pairs in 3 matched pairs dice scoring.

## Why?
It's a good demo and fun little game of Zonk, so I just wanted to fix this bug so it doesn't distract from the point of the sample.

## Checklist

1. Closes #55

2. How was this tested:
2.1. Pretest: Modify app/src/Updates/Zonk/Dice.php to force 1 or 2 number variations total.
```
diff --git a/app/src/Updates/Zonk/Dice.php b/app/src/Updates/Zonk/Dice.php
index 216d37a..1b95da6 100644
--- a/app/src/Updates/Zonk/Dice.php
+++ b/app/src/Updates/Zonk/Dice.php
@@ -37,6 +37,6 @@ final class Dice
 
     private function roll(): int
     {
-        return $this->value = \random_int(1, 6);
+        return $this->value = \random_int(3, 4); //force 3's and 4's to increase the likelyhood of 3 pairs of repeated pairs: 3,3; 4,4; 4,4;
     }
 }
```
2.2. Play the game until you have 3 matched pairs. In this test case, two or more pairs will repeat.
2.3. Select all pairs. 
2.4. Expected result: "Your total score is 750 (+750)"