### PR TITLE
Add Workflow Inbound Calls Logger

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -2,7 +2,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "temporal/sdk": "^2.8.0",
+    "temporal/sdk": "^2.12.0",
     "spiral/tokenizer": "^3.7",
     "temporal/open-telemetry-interceptors": "dev-master",
     "open-telemetry/exporter-otlp": "^1.0",
@@ -20,7 +20,8 @@
   },
   "config": {
     "allow-plugins": {
-      "php-http/discovery": true
+      "php-http/discovery": true,
+      "tbachert/spi": false
     }
   }
 }

--- a/app/src/Interceptors/Interceptor/LoggerWorkflowInboundCallsInterceptor.php
+++ b/app/src/Interceptors/Interceptor/LoggerWorkflowInboundCallsInterceptor.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This file is part of Temporal package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Temporal\Samples\Interceptors\Interceptor;
+
+use Psr\Log\LoggerInterface;
+use Temporal\Interceptor\Trait\WorkflowInboundCallsInterceptorTrait;
+use Temporal\Interceptor\WorkflowInbound\QueryInput;
+use Temporal\Interceptor\WorkflowInbound\SignalInput;
+use Temporal\Interceptor\WorkflowInbound\UpdateInput;
+use Temporal\Interceptor\WorkflowInbound\WorkflowInput;
+use Temporal\Interceptor\WorkflowInboundCallsInterceptor;
+
+final class LoggerWorkflowInboundCallsInterceptor implements WorkflowInboundCallsInterceptor
+{
+    use WorkflowInboundCallsInterceptorTrait;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function execute(WorkflowInput $input, callable $next): void
+    {
+        $input->info->isReplaying or $this->log(
+            "Executing workflow {$input->info->type->name}",
+            [
+                'workflowId' => $input->info->execution->getID(),
+                'runId' => $input->info->execution->getRunID(),
+                'headers' => $input->header,
+                'arguments' => $input->arguments->getValues(),
+            ],
+        );
+
+        $next($input);
+    }
+
+    public function handleSignal(SignalInput $input, callable $next): void
+    {
+        $input->info->isReplaying or $this->log(
+            "Handling signal {$input->info->type->name}->{$input->signalName}",
+            [
+                'workflowId' => $input->info->execution->getID(),
+                'runId' => $input->info->execution->getRunID(),
+                'headers' => $input->header,
+                'arguments' => $input->arguments->getValues(),
+            ],
+        );
+
+        $next($input);
+    }
+
+    public function handleQuery(QueryInput $input, callable $next): mixed
+    {
+        $this->log(
+            "Handling query {$input->info->type->name}->{$input->queryName}",
+            [
+                'workflowId' => $input->info->execution->getID(),
+                'runId' => $input->info->execution->getRunID(),
+                'arguments' => $input->arguments->getValues(),
+            ],
+        );
+
+        return $next($input);
+    }
+
+    public function handleUpdate(UpdateInput $input, callable $next): mixed
+    {
+        $input->info->isReplaying or $this->log(
+            "Handling update {$input->info->type->name}->{$input->updateName}",
+            [
+                'workflowId' => $input->info->execution->getID(),
+                'runId' => $input->info->execution->getRunID(),
+                'updateId' => $input->updateId,
+                'headers' => $input->header,
+                'arguments' => $input->arguments->getValues(),
+            ],
+        );
+
+        return $next($input);
+    }
+
+    public function validateUpdate(UpdateInput $input, callable $next): void
+    {
+        $next($input);
+    }
+
+    private function log(string $message, array $context = []): void
+    {
+        $this->logger->info($message, $context);
+    }
+}

--- a/app/src/Interceptors/Interceptor/RequestLoggerInterceptor.php
+++ b/app/src/Interceptors/Interceptor/RequestLoggerInterceptor.php
@@ -19,9 +19,8 @@ use Temporal\Worker\Transport\Command\RequestInterface;
 final class RequestLoggerInterceptor implements WorkflowOutboundRequestInterceptor
 {
     public function __construct(
-        private LoggerInterface $logger,
-    ) {
-    }
+        private readonly LoggerInterface $logger,
+    ) {}
 
     public function handleOutboundRequest(RequestInterface $request, callable $next): PromiseInterface
     {

--- a/app/src/Interceptors/README.md
+++ b/app/src/Interceptors/README.md
@@ -4,6 +4,7 @@ This sample demonstrates how you can use Interceptors.
 
 There are few interceptors:
 - RequestLoggerInterceptor - logs all internal requests from the Workflow into the RoadRunner log.
+- WorkflowInboundLogger - logs all inbound workflow calls to the RoadRunner log.
 - ActivityAttributesInterceptor - reads [ActivityOption](./Attribute/ActivityOption.php) attributes and applies them to the Activity options.
 
 ```bash

--- a/app/src/Interceptors/worker.php
+++ b/app/src/Interceptors/worker.php
@@ -13,17 +13,21 @@ use Temporal\Interceptor\SimplePipelineProvider;
 use Temporal\Samples\Interceptors\Activity\Sleeper;
 use Temporal\Samples\Interceptors\Interceptor\ActivityAttributesInterceptor;
 use Temporal\Samples\Interceptors\Interceptor\RequestLoggerInterceptor;
+use Temporal\Samples\Interceptors\Interceptor\LoggerWorkflowInboundCallsInterceptor;
 use Temporal\Samples\Interceptors\Workflow\TestActivityAttributesInterceptor;
+use Temporal\SampleUtils\Logger;
 use Temporal\WorkerFactory;
 
 ini_set('display_errors', 'stderr');
 include "../../vendor/autoload.php";
 
 $factory = WorkerFactory::create();
+$logger = new Logger();
 
 $worker = $factory->newWorker(taskQueue: 'interceptors', interceptorProvider: new SimplePipelineProvider([
-    new RequestLoggerInterceptor(new \Temporal\SampleUtils\Logger()),
-    new ActivityAttributesInterceptor()
+    new RequestLoggerInterceptor($logger),
+    new ActivityAttributesInterceptor(),
+    new LoggerWorkflowInboundCallsInterceptor($logger),
 ]))
     ->registerWorkflowTypes(TestActivityAttributesInterceptor::class)
     ->registerActivityImplementations(new Sleeper());


### PR DESCRIPTION
## What was changed

Added Add Workflow Inbound Calls Logger Interceptor that logs all the Workflow inbound calls

## Why?
The capability to create a custom logger with the provision of all necessary contexts is demonstrated.

## Checklist

- [x] Wait https://github.com/temporalio/sdk-php/pull/528 
- [x] Wait release SDK 2.12.0